### PR TITLE
Places render after abort

### DIFF
--- a/src/components/fetch-wrapper.jsx
+++ b/src/components/fetch-wrapper.jsx
@@ -28,23 +28,6 @@ function withFetching(WrappedComponent, props) {
       this.abort();
     }
 
-    render() {
-      if (!this.xhr) {
-        return <h1>CORS not supported..</h1>;
-      }
-
-      if (this.state.error) {
-        return <Error {...this.props} error={this.state.error} />;
-      }
-
-      if (this.state.data) {
-        return <WrappedComponent data={this.state.data} {...this.props} />;
-      }
-      return (
-        <Loading />
-      );
-    }
-
     createRequest(path) {
       let xhr = new XMLHttpRequest();
 
@@ -85,6 +68,23 @@ function withFetching(WrappedComponent, props) {
       if (this.xhr) {
         this.xhr.abort();
       }
+    }
+
+    render() {
+      if (!this.xhr) {
+        return <h1>CORS not supported..</h1>;
+      }
+
+      if (this.state.error) {
+        return <Error {...this.props} error={this.state.error} />;
+      }
+
+      if (this.state.data) {
+        return <WrappedComponent data={this.state.data} {...this.props} />;
+      }
+      return (
+        <Loading />
+      );
     }
   };
 }


### PR DESCRIPTION
When running `npm start` the build fails with:

```
ERROR in ./src/components/fetch-wrapper.jsx

/path/to/react-file-viewer/src/components/fetch-wrapper.jsx
  31:5  error  render should be placed after abort  react/sort-comp

✖ 1 problem (1 error, 0 warnings)
```

By changing the order as suggested the error seems to be resolved.

You mention a CLA in the contributing guidelines. However it's not clear how to submit this. I can't find any bot, that could fail to recognize it. 

