### PR TITLE
DOC-384 Allow custom component for unsupported file formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ There is one main React component, `FileViewer`, that takes the following props:
 
 `fileType` string: type of resource to be shown (one of the supported file
 formats, eg `'png'`). Passing in an unsupported file type will result in displaying
-an `unsupported file type` message.
+an `unsupported file type` message (or a custom component).
 
 `filePath` string: the url of the resource to be shown by the FileViewer.
 
@@ -31,7 +31,10 @@ pass a callback for a logging utility.
 `errorComponent` react element [optional]: A component to render in case of error
 instead of the default error component that comes packaged with react-file-viewer.
 
-So, to use this component, you might do the following:
+`unsupportedComponent` react element [optional]: A component to render in case
+the file format is not supported.
+
+To use a custom error component, you might do the following:
 
 ```
 // MyApp.js

--- a/example_files/sample.rtf
+++ b/example_files/sample.rtf
@@ -1,0 +1,141 @@
+{\rtf1\ansi\ansicpg1252\cocoartf1561\cocoasubrtf200
+{\fonttbl\f0\fswiss\fcharset0 ArialMT;\f1\froman\fcharset0 TimesNewRomanPSMT;\f2\fmodern\fcharset0 CourierNewPSMT;
+\f3\ftech\fcharset77 Symbol;}
+{\colortbl;\red255\green255\blue255;\red255\green0\blue0;\red191\green191\blue191;}
+{\*\expandedcolortbl;;\csgenericrgb\c100000\c0\c0;\csgray\c79525;}
+{\info
+{\author Lexis Nexis Group}
+{\operator Lexis Nexis Group}
+{\*\company MBCO}
+{\creatim\yr2001\mo9\dy10\hr14\min52\sec0\timesinceref21851520}
+{\revtim\yr2003\mo2\dy10\hr12\min46\sec0\timesinceref66602760}}\viewkind1
+\deftab720
+\pard\pardeftab720\sb240\sa60\pardirnatural\partightenfactor0
+
+\f0\b\fs32 \cf0 This is Heading1 Text\
+\pard\pardeftab720\pardirnatural\partightenfactor0
+
+\f1\b0\fs24 \cf0 This is a regular paragraph with the default style of Normal. This is a regular paragraph with the default style of Normal. This is a regular paragraph with the default style of Normal. This is a regular paragraph with the default style of Normal. This is a regular paragraph with the default style of Normal.\
+\pard\pardeftab720\sb120\sa120\pardirnatural\partightenfactor0
+
+\f0\i\b\fs28 \cf0 This is a Defined Block Style Called BlockStyleTest\
+\pard\pardeftab720\pardirnatural\partightenfactor0
+
+\f1\i0\b0\fs24 \cf0 This is more Normal text.\
+\pard\pardeftab720\sb240\sa60\pardirnatural\partightenfactor0
+
+\f0\i\b\fs28 \cf0 This is Heading 2 text\
+\pard\pardeftab720\pardirnatural\partightenfactor0
+
+\f1\i0\b0\fs24 \cf0 This is more Normal text. 
+\b This is bold, 
+\i\b0 this is italic
+\i0 , 
+\i\b and this is bold italic
+\i0\b0 . This is normal. 
+\f2\fs18 This is in a defined inline style called InlineStyle
+\f1\fs24 . This is normal. \cf2 This is red text.\cf0  This is normal. \
+\pard\pardeftab720\pardirnatural\qc\partightenfactor0
+\cf0 This block is centered.\
+\pard\pardeftab720\pardirnatural\partightenfactor0
+\cf0 This is left-aligned. \
+\
+First item of bulleted list. \
+Second item of bulleted list.\
+\pard\pardeftab720\li720\pardirnatural\partightenfactor0
+\cf0 Second paragraph of second item of bulleted list. \
+\pard\pardeftab720\pardirnatural\partightenfactor0
+\cf0 Third item of bulleted list.\
+First item of third item\'92s nested list\
+Second item of third item\'92s nested list\
+Fourth and final item of main bulleted list.\
+\
+This is Normal text.\
+\
+First item of numbered list. \
+Second item of numbered list.\
+\pard\pardeftab720\li720\pardirnatural\partightenfactor0
+\cf0 Second paragraph of second item of numbered list. \
+\pard\pardeftab720\pardirnatural\partightenfactor0
+\cf0 Third item of numbered list.\
+\
+Here is a BMP picture:\
+\
+Here is a table:\
+
+\itap1\trowd \taflags1 \trgaph108\trleft-108 \trbrdrt\brdrnil \trbrdrl\brdrnil \trbrdrr\brdrnil 
+\clvertalt \clshdrawnil \clminw1771 \clbrdrt\brdrs\brdrw20\brdrcf3 \clbrdrl\brdrs\brdrw20\brdrcf3 \clbrdrb\brdrs\brdrw20\brdrcf3 \clbrdrr\brdrs\brdrw20\brdrcf3 \clpadl100 \clpadr100 \gaph\cellx1728
+\clvertalt \clshdrawnil \clminw3542 \clbrdrt\brdrs\brdrw20\brdrcf3 \clbrdrl\brdrs\brdrw20\brdrcf3 \clbrdrb\brdrs\brdrw20\brdrcf3 \clbrdrr\brdrs\brdrw20\brdrcf3 \clpadl100 \clpadr100 \gaph\cellx3456
+\clvertalt \clshdrawnil \clminw1771 \clbrdrt\brdrs\brdrw20\brdrcf3 \clbrdrl\brdrs\brdrw20\brdrcf3 \clbrdrb\brdrs\brdrw20\brdrcf3 \clbrdrr\brdrs\brdrw20\brdrcf3 \clpadl100 \clpadr100 \gaph\cellx5184
+\clvertalt \clshdrawnil \clminw1772 \clbrdrt\brdrs\brdrw20\brdrcf3 \clbrdrl\brdrs\brdrw20\brdrcf3 \clbrdrb\brdrs\brdrw20\brdrcf3 \clbrdrr\brdrs\brdrw20\brdrcf3 \clpadl100 \clpadr100 \gaph\cellx6912
+\clmrg \clvertalt \clshdrawnil \clminw1772 \clbrdrt\brdrs\brdrw20\brdrcf3 \clbrdrl\brdrs\brdrw20\brdrcf3 \clbrdrb\brdrs\brdrw20\brdrcf3 \clbrdrr\brdrs\brdrw20\brdrcf3 \clpadl100 \clpadr100 \gaph\cellx8640
+\pard\intbl\itap1\pardeftab720\pardirnatural\partightenfactor0
+\cf0 \cell 
+\pard\intbl\itap1\pardeftab720\pardirnatural\qc\partightenfactor0
+\cf0 New York\cell 
+\pard\intbl\itap1\pardeftab720\pardirnatural\qc\partightenfactor0
+\cf0 Boston\cell 
+\pard\intbl\itap1\pardeftab720\pardirnatural\qc\partightenfactor0
+\cf0 Detroit\cell 
+\pard\intbl\itap1\cell \row
+
+\itap1\trowd \taflags1 \trgaph108\trleft-108 \trbrdrl\brdrnil \trbrdrr\brdrnil 
+\clvertalt \clshdrawnil \clminw1771 \clbrdrt\brdrs\brdrw20\brdrcf3 \clbrdrl\brdrs\brdrw20\brdrcf3 \clbrdrb\brdrs\brdrw20\brdrcf3 \clbrdrr\brdrs\brdrw20\brdrcf3 \clpadl100 \clpadr100 \gaph\cellx1728
+\clvertalt \clshdrawnil \clminw1771 \clbrdrt\brdrs\brdrw20\brdrcf3 \clbrdrl\brdrs\brdrw20\brdrcf3 \clbrdrb\brdrs\brdrw20\brdrcf3 \clbrdrr\brdrs\brdrw20\brdrcf3 \clpadl100 \clpadr100 \gaph\cellx3456
+\clvertalt \clshdrawnil \clminw1771 \clbrdrt\brdrs\brdrw20\brdrcf3 \clbrdrl\brdrs\brdrw20\brdrcf3 \clbrdrb\brdrs\brdrw20\brdrcf3 \clbrdrr\brdrs\brdrw20\brdrcf3 \clpadl100 \clpadr100 \gaph\cellx5184
+\clvertalt \clshdrawnil \clminw1771 \clbrdrt\brdrs\brdrw20\brdrcf3 \clbrdrl\brdrs\brdrw20\brdrcf3 \clbrdrb\brdrs\brdrw20\brdrcf3 \clbrdrr\brdrs\brdrw20\brdrcf3 \clpadl100 \clpadr100 \gaph\cellx6912
+\clvertalt \clshdrawnil \clminw1772 \clbrdrt\brdrs\brdrw20\brdrcf3 \clbrdrl\brdrs\brdrw20\brdrcf3 \clbrdrb\brdrs\brdrw20\brdrcf3 \clbrdrr\brdrs\brdrw20\brdrcf3 \clpadl100 \clpadr100 \gaph\cellx8640
+\pard\intbl\itap1\pardeftab720\pardirnatural\partightenfactor0
+\cf0 Baseball\cell 
+\pard\intbl\itap1\pardeftab720\pardirnatural\partightenfactor0
+\cf0 Mets\cell 
+\pard\intbl\itap1\pardeftab720\pardirnatural\partightenfactor0
+\cf0 Yankees\cell 
+\pard\intbl\itap1\pardeftab720\pardirnatural\partightenfactor0
+\cf0 Red Sox\cell 
+\pard\intbl\itap1\pardeftab720\pardirnatural\partightenfactor0
+\cf0 Tigers\cell \row
+
+\itap1\trowd \taflags1 \trgaph108\trleft-108 \trbrdrl\brdrnil \trbrdrr\brdrnil 
+\clvertalt \clshdrawnil \clminw1771 \clbrdrt\brdrs\brdrw20\brdrcf3 \clbrdrl\brdrs\brdrw20\brdrcf3 \clbrdrb\brdrs\brdrw20\brdrcf3 \clbrdrr\brdrs\brdrw20\brdrcf3 \clpadl100 \clpadr100 \gaph\cellx1728
+\clvertalt \clshdrawnil \clminw1771 \clbrdrt\brdrs\brdrw20\brdrcf3 \clbrdrl\brdrs\brdrw20\brdrcf3 \clbrdrb\brdrs\brdrw20\brdrcf3 \clbrdrr\brdrs\brdrw20\brdrcf3 \clpadl100 \clpadr100 \gaph\cellx3456
+\clvertalt \clshdrawnil \clminw1771 \clbrdrt\brdrs\brdrw20\brdrcf3 \clbrdrl\brdrs\brdrw20\brdrcf3 \clbrdrb\brdrs\brdrw20\brdrcf3 \clbrdrr\brdrs\brdrw20\brdrcf3 \clpadl100 \clpadr100 \gaph\cellx5184
+\clvertalt \clshdrawnil \clminw1771 \clbrdrt\brdrs\brdrw20\brdrcf3 \clbrdrl\brdrs\brdrw20\brdrcf3 \clbrdrb\brdrs\brdrw20\brdrcf3 \clbrdrr\brdrs\brdrw20\brdrcf3 \clpadl100 \clpadr100 \gaph\cellx6912
+\clvertalt \clshdrawnil \clminw1772 \clbrdrt\brdrs\brdrw20\brdrcf3 \clbrdrl\brdrs\brdrw20\brdrcf3 \clbrdrb\brdrs\brdrw20\brdrcf3 \clbrdrr\brdrs\brdrw20\brdrcf3 \clpadl100 \clpadr100 \gaph\cellx8640
+\pard\intbl\itap1\pardeftab720\pardirnatural\partightenfactor0
+\cf0 Hockey\cell 
+\pard\intbl\itap1\pardeftab720\pardirnatural\partightenfactor0
+\cf0 Rangers\cell 
+\pard\intbl\itap1\pardeftab720\pardirnatural\partightenfactor0
+\cf0 Islanders\cell 
+\pard\intbl\itap1\pardeftab720\pardirnatural\partightenfactor0
+\cf0 Bruins\cell 
+\pard\intbl\itap1\pardeftab720\pardirnatural\partightenfactor0
+\cf0 Red Wings\cell \row
+
+\itap1\trowd \taflags1 \trgaph108\trleft-108 \trbrdrl\brdrnil \trbrdrt\brdrnil \trbrdrr\brdrnil 
+\clvertalt \clshdrawnil \clminw1771 \clbrdrt\brdrs\brdrw20\brdrcf3 \clbrdrl\brdrs\brdrw20\brdrcf3 \clbrdrb\brdrs\brdrw20\brdrcf3 \clbrdrr\brdrs\brdrw20\brdrcf3 \clpadl100 \clpadr100 \gaph\cellx1728
+\clvertalt \clshdrawnil \clminw1771 \clbrdrt\brdrs\brdrw20\brdrcf3 \clbrdrl\brdrs\brdrw20\brdrcf3 \clbrdrb\brdrs\brdrw20\brdrcf3 \clbrdrr\brdrs\brdrw20\brdrcf3 \clpadl100 \clpadr100 \gaph\cellx3456
+\clvertalt \clshdrawnil \clminw1771 \clbrdrt\brdrs\brdrw20\brdrcf3 \clbrdrl\brdrs\brdrw20\brdrcf3 \clbrdrb\brdrs\brdrw20\brdrcf3 \clbrdrr\brdrs\brdrw20\brdrcf3 \clpadl100 \clpadr100 \gaph\cellx5184
+\clvertalt \clshdrawnil \clminw1771 \clbrdrt\brdrs\brdrw20\brdrcf3 \clbrdrl\brdrs\brdrw20\brdrcf3 \clbrdrb\brdrs\brdrw20\brdrcf3 \clbrdrr\brdrs\brdrw20\brdrcf3 \clpadl100 \clpadr100 \gaph\cellx6912
+\clvertalt \clshdrawnil \clminw1772 \clbrdrt\brdrs\brdrw20\brdrcf3 \clbrdrl\brdrs\brdrw20\brdrcf3 \clbrdrb\brdrs\brdrw20\brdrcf3 \clbrdrr\brdrs\brdrw20\brdrcf3 \clpadl100 \clpadr100 \gaph\cellx8640
+\pard\intbl\itap1\pardeftab720\pardirnatural\partightenfactor0
+\cf0 Football\cell 
+\pard\intbl\itap1\pardeftab720\pardirnatural\partightenfactor0
+\cf0 Giants\cell 
+\pard\intbl\itap1\pardeftab720\pardirnatural\partightenfactor0
+\cf0 Jets\cell 
+\pard\intbl\itap1\pardeftab720\pardirnatural\partightenfactor0
+\cf0 Patriots\cell 
+\pard\intbl\itap1\pardeftab720\pardirnatural\partightenfactor0
+\cf0 Lions\cell \lastrow\row
+\pard\pardeftab720\pardirnatural\partightenfactor0
+\cf0 \
+Here is an embedded Excel spreadsheet:\
+\
+ EMBED Excel.Sheet.8  \
+\
+This concludes our test.\
+
+\f3\fs32 \
+}

--- a/src/app.js
+++ b/src/app.js
@@ -17,6 +17,7 @@ import avi from '../example_files/drop.avi';
 import webm from '../example_files/small.webm'
 import mov from '../example_files/step.mov'
 import mp3 from '../example_files/sample.mp3'
+import rtf from '../example_files/sample.rtf';
 
 ReactDOM.render(
   <FileViewer

--- a/src/components/drivers/unsupported-viewer.jsx
+++ b/src/components/drivers/unsupported-viewer.jsx
@@ -6,7 +6,9 @@ import 'styles/unsupported.scss';
 const UnsupportedViewer = props => (
   <div className="pg-driver-view">
     <div className="unsupported-message">
-      <b>{`.${props.fileType}`}</b> is not supported.
+      {props.unsupportedComponent
+        ? <props.unsupportedComponent {...props} />
+        : <p className="alert"><b>{`.${props.fileType}`}</b> is not supported.</p>}
     </div>
   </div>
 );

--- a/src/components/file-viewer.jsx
+++ b/src/components/file-viewer.jsx
@@ -87,11 +87,13 @@ FileViewer.propTypes = {
   filePath: PropTypes.string.isRequired,
   onError: PropTypes.func,
   errorComponent: PropTypes.element,
+  unsupportedComponent: PropTypes.element,
 };
 
 FileViewer.defaultProps = {
   onError: () => null,
   errorComponent: null,
+  unsupportedComponent: null,
 };
 
 export default FileViewer;

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -73,7 +73,7 @@ module.exports = {
         enforce: 'pre',
       },
       {
-        test: [/\.wexbim$/, /\.jpg$/, /\.docx$/, /\.csv$/, /\.mp4$/, /\.xlsx$/, /\.doc$/, /\.avi$/, /\.webm$/, /\.mov$/, /\.mp3$/],
+        test: [/\.wexbim$/, /\.jpg$/, /\.docx$/, /\.csv$/, /\.mp4$/, /\.xlsx$/, /\.doc$/, /\.avi$/, /\.webm$/, /\.mov$/, /\.mp3$/, /\.rtf$/],
         loader: 'file-loader',
       },
       {


### PR DESCRIPTION
Adds a property `unsupportedComponent` to specify a custom component to use if the file format is not supported. This is based on the existing `errorComponent` property.