### PR TITLE
FIELD-2756 disable pdf.js worker

### DIFF
--- a/src/components/drivers/pdf-viewer.jsx
+++ b/src/components/drivers/pdf-viewer.jsx
@@ -1,9 +1,11 @@
 // Copyright (c) 2017 PlanGrid, Inc.
 
-import { PDFJS } from 'pdfjs-dist';
 import React from 'react';
 import VisibilitySensor from 'react-visibility-sensor';
+import { PDFJS } from 'pdfjs-dist/build/pdf.combined';
+import 'pdfjs-dist/web/compatibility';
 
+PDFJS.disableWorker = true;
 const INCREASE_PERCENTAGE = 0.2;
 const DEFAULT_SCALE = 1.1;
 


### PR DESCRIPTION
After some investigation around issues with `Error: Loading chunk 0 failed.` I came to conclusion that current implementation of pdf-viewer assumes that pdf worker is already set up by the consumer app (which is not always the case).

Changes in this PR
• import only necessary files from pdfjs library
• disable pdf.js worker

This is not ideal solution bc disabling worker degrades performance, but on other hand it allows us to use pdf-viewer without extra setup in consumer app.

Fixes next issues: https://github.com/plangrid/react-file-viewer/issues/64 and https://github.com/plangrid/react-file-viewer/issues/69