### PR TITLE
removed reference to window in getPhotoDriver to fix ssr

### DIFF
--- a/src/components/drivers/photo-viewer-wrapper.jsx
+++ b/src/components/drivers/photo-viewer-wrapper.jsx
@@ -8,7 +8,7 @@ import Photo360Viewer from './photo360-viewer';
 import Loading from '../loading';
 
 function getPhotoDriver(width, height, fileType) {
-  if (fileType === 'jpg' && window.Math.abs((width / height) - 2) <= 0.01) {
+  if (fileType === 'jpg' && Math.abs((width / height) - 2) <= 0.01) {
     return Photo360Viewer;
   }
   return PhotoViewer;


### PR DESCRIPTION
Addresses #91 
A small change to the getPhotoDriver method should allow the react components to initially render on a Node server, so this library can be used with NextJS or similar server rendering libraries.