### PR TITLE
update mammoth version to avoid vuln

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   },
   "dependencies": {
     "comma-separated-values": "^3.6.4",
-    "mammoth": "1.3.6",
+    "mammoth": "1.4.8",
     "pdfjs-dist": "1.8.357",
     "prop-types": "^15.5.10",
     "react-data-grid": "^5.0.5",


### PR DESCRIPTION
1.3.6 uses an vulnerable version of xmlbuilder (via lodash). This updates it to a non-vulnerable version.