### PR TITLE
Compatible to render multiple Docx-viewer

### DIFF
--- a/src/components/drivers/docx-viewer.jsx
+++ b/src/components/drivers/docx-viewer.jsx
@@ -7,6 +7,9 @@ import 'styles/docx.scss';
 import Loading from '../loading';
 
 export default class extends Component {
+  state = {
+    file:'',
+  }
   componentDidMount() {
     const jsonFile = new XMLHttpRequest();
     jsonFile.open('GET', this.props.filePath, true);
@@ -22,7 +25,7 @@ export default class extends Component {
           const docEl = document.createElement('div');
           docEl.className = 'document-container';
           docEl.innerHTML = result.value;
-          document.getElementById('docx').innerHTML = docEl.outerHTML;
+          this.setState({file:docEl.outerHTML})
         })
         .catch((a) => {
           console.log('alexei: something went wrong', a);
@@ -34,8 +37,17 @@ export default class extends Component {
 
   render() {
     return (
-      <div id="docx">
-        <Loading />
-      </div>);
+      <div>
+        {file ? (
+          <div dangerouslySetInnerHTML={{ __html: file }}>
+          </div>
+        ) : (
+          <div>
+          <Loading />
+          </div>
+        )}
+      </div>
+    );
+    
   }
 }


### PR DESCRIPTION
When multiple components are introduced into a page, the id conflict.
Use dangerouslySetInnerHTML dynamic binding to avoid creating multiple elements with the same ID.