### PR TITLE
feature:  JWT support for docx-viewer

### DIFF
--- a/src/components/drivers/docx-viewer.jsx
+++ b/src/components/drivers/docx-viewer.jsx
@@ -10,6 +10,8 @@ export default class extends Component {
   componentDidMount() {
     const jsonFile = new XMLHttpRequest();
     jsonFile.open('GET', this.props.filePath, true);
+    jsonFile.setRequestHeader('Authorization', 'Bearer ' + this.props.jwtoken);
+
     jsonFile.send();
     jsonFile.responseType = 'arraybuffer';
     jsonFile.onreadystatechange = () => {

--- a/src/components/file-viewer.jsx
+++ b/src/components/file-viewer.jsx
@@ -85,6 +85,8 @@ class FileViewer extends Component {
 FileViewer.propTypes = {
   fileType: PropTypes.string.isRequired,
   filePath: PropTypes.string.isRequired,
+  jwt: PropTypes.string,
+
   onError: PropTypes.func,
   errorComponent: PropTypes.element,
   unsupportedComponent: PropTypes.element,


### PR DESCRIPTION
- [x] Added JWT as a prop, and use it in docx-viewer.jsx
- [x] Added JWT PropType in fetch-wrapper.jsx

https://github.com/plangrid/react-file-viewer/issues/77